### PR TITLE
don't close command palette when opening link

### DIFF
--- a/components/search/CommandPalette.tsx
+++ b/components/search/CommandPalette.tsx
@@ -110,7 +110,7 @@ export default function CommandPalette({ commands, noOpacity = false }: Props) {
 
               command.link && event(command.link, { name: command.name });
 
-              closeSearch();
+              !command.link && closeSearch();
             }}
             as="div"
             className="border-base-content  bg-base-100 d group relative flex h-screen flex-col justify-end overflow-hidden overflow-y-auto font-mono ring-1 ring-black/5 sm:h-auto sm:max-h-fit sm:rounded-lg sm:border-4 sm:shadow-black"


### PR DESCRIPTION
### Problem
> What problem does this solve?  Roughly how urgent/severe is this?
Problem: In user interview with nibblez, he mentioned how annoying it was to have to reopen when returning back from an external link.

Solution: if it's a link, do not dispatch a call to close search (redux)

### Test Plan
> Did you add unit tests?  Does this require any manual review?  What should reviewers do to verify this code?
1. Try opening link on preview deployment



### Checklist (please confirm by adding x in brackets)
- [x] Relevant unit tests written if any.  (At bare minimum `todo` tests should be defined.)
- [x] Commit(s) do one thing and one thing only.
